### PR TITLE
feat: 파일 업로드 기능 구현

### DIFF
--- a/src/main/java/com/pawpaw/pawpaw/global/config/AppConfig.java
+++ b/src/main/java/com/pawpaw/pawpaw/global/config/AppConfig.java
@@ -1,13 +1,26 @@
 package com.pawpaw.pawpaw.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class AppConfig {
+public class AppConfig implements WebMvcConfigurer {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/files/**")
+                .addResourceLocations("file:" + uploadDir + "/");
     }
 }

--- a/src/main/java/com/pawpaw/pawpaw/global/config/SecurityConfig.java
+++ b/src/main/java/com/pawpaw/pawpaw/global/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()
+                        .requestMatchers("/files/**").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService),
                         UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/pawpaw/pawpaw/global/upload/FileService.java
+++ b/src/main/java/com/pawpaw/pawpaw/global/upload/FileService.java
@@ -1,0 +1,45 @@
+package com.pawpaw.pawpaw.global.upload;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@Service
+public class FileService {
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    @Value("${file.base-url}")
+    private String baseUrl;
+
+    public String upload(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new IllegalArgumentException("파일이 비어 있습니다.");
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        String extension = (originalFilename != null && originalFilename.contains("."))
+                ? originalFilename.substring(originalFilename.lastIndexOf("."))
+                : "";
+        String filename = UUID.randomUUID() + extension;
+
+        try {
+            Path dir = Paths.get(uploadDir);
+            if (!Files.exists(dir)) {
+                Files.createDirectories(dir);
+            }
+            file.transferTo(dir.resolve(filename));
+        } catch (IOException e) {
+            throw new RuntimeException("파일 저장에 실패했습니다.", e);
+        }
+
+        return baseUrl + "/files/" + filename;
+    }
+}

--- a/src/main/java/com/pawpaw/pawpaw/global/upload/UploadController.java
+++ b/src/main/java/com/pawpaw/pawpaw/global/upload/UploadController.java
@@ -1,0 +1,25 @@
+package com.pawpaw.pawpaw.global.upload;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/upload")
+@RequiredArgsConstructor
+public class UploadController {
+
+    private final FileService fileService;
+
+    @PostMapping
+    public ResponseEntity<Map<String, String>> upload(@RequestParam("file") MultipartFile file) {
+        String url = fileService.upload(file);
+        return ResponseEntity.ok(Map.of("url", url));
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,14 @@ spring:
       hibernate:
         format_sql: true
     show-sql: true
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
 server:
   port: 8080
+
+file:
+  upload-dir: ${user.home}/pawpaw-uploads
+  base-url: http://localhost:8080


### PR DESCRIPTION
## Summary
- `POST /api/upload`: 이미지 파일 업로드 후 URL 반환
- 로컬 파일 시스템 저장 (UUID 기반 파일명, 중복 방지)
- `/files/**` 정적 리소스 서빙 및 인증 없이 접근 허용
- multipart 파일 크기 제한 10MB 설정

## Test plan
- [ ] `POST /api/upload`로 이미지 업로드 후 url 반환 확인
- [ ] 반환된 URL로 이미지 직접 접근 확인
- [ ] 빈 파일 업로드 시 400 에러 확인
- [ ] 10MB 초과 파일 업로드 시 에러 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)