### PR TITLE
fix: 펫 나이 음수 입력 방지 유효성 검사 추가

### DIFF
--- a/src/main/java/com/pawpaw/pawpaw/domain/pet/dto/PetRequestDto.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/pet/dto/PetRequestDto.java
@@ -1,5 +1,6 @@
 package com.pawpaw.pawpaw.domain.pet.dto;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
@@ -13,6 +14,8 @@ public class PetRequestDto {
     private String species;
 
     private String breed;
+
+    @Min(0)
     private Integer age;
     private String gender;
     private Double weight;

--- a/src/main/java/com/pawpaw/pawpaw/domain/pet/dto/PetResponseDto.java
+++ b/src/main/java/com/pawpaw/pawpaw/domain/pet/dto/PetResponseDto.java
@@ -22,7 +22,7 @@ public class PetResponseDto {
         this.name = pet.getName();
         this.species = pet.getSpecies();
         this.breed = pet.getBreed();
-        this.age = pet.getAge();
+        this.age = pet.getAge() != null ? Math.max(0, pet.getAge()) : null;
         this.gender = pet.getGender();
         this.weight = pet.getWeight();
         this.photoUrl = pet.getPhotoUrl();


### PR DESCRIPTION
## Summary
- `PetRequestDto` age 필드에 `@Min(0)` 추가 (음수 입력 차단)
- `PetResponseDto`에서 기존에 저장된 음수값 방어적 처리 (`Math.max(0, age)`)

## Test plan
- [ ] 나이에 음수 값 입력 시 400 에러 확인
- [ ] 정상 나이 입력 시 정상 저장 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)